### PR TITLE
Remove arbitrary 8k bullet range limitation. Read MAX_BULLET_RANGE from the config file.

### DIFF
--- a/BahaTurret/BDArmorySettings.cs
+++ b/BahaTurret/BDArmorySettings.cs
@@ -522,6 +522,8 @@ namespace BahaTurret
 
 				if(cfg.HasValue("SMART_GUARDS")) SMART_GUARDS = Boolean.Parse(cfg.GetValue("SMART_GUARDS"));
 
+				if(cfg.HasValue("MAX_BULLET_RANGE")) MAX_BULLET_RANGE = float.Parse(cfg.GetValue("MAX_BULLET_RANGE"));	
+
 				if(cfg.HasValue("TRIGGER_HOLD_TIME")) TRIGGER_HOLD_TIME = float.Parse(cfg.GetValue("TRIGGER_HOLD_TIME"));
 
 				if(cfg.HasValue("ALLOW_LEGACY_TARGETING")) ALLOW_LEGACY_TARGETING = bool.Parse(cfg.GetValue("ALLOW_LEGACY_TARGETING"));

--- a/BahaTurret/PooledBullet.cs
+++ b/BahaTurret/PooledBullet.cs
@@ -71,8 +71,7 @@ namespace BahaTurret
 			startPosition = transform.position;
 			collisionEnabled = false;
 
-			float maxLimit = Mathf.Clamp(BDArmorySettings.MAX_BULLET_RANGE, 0, 8000);
-			maxDistance = Mathf.Clamp(BDArmorySettings.PHYSICS_RANGE, 2500, maxLimit);
+			maxDistance = Mathf.Clamp(BDArmorySettings.PHYSICS_RANGE, 2500, BDArmorySettings.MAX_BULLET_RANGE);
 			if(!wasInitiated)
 			{
 				projectileColor.a = projectileColor.a/2;


### PR DESCRIPTION
I needed longer than the default 5km ranges for my space battles, so I made a quick fix to adress that. Bullets now fly all the way to the PHYSICS_RANGE or MAX_BULLET_RANGE, whichever happens to be smaller, and MAX_BULLET_RANGE is now read from the config file as it was probably intented to be.
