### PR TITLE
Read MAX_GUARD_VISUAL_RANGE from the config file. Use guns on 10km+ ranges if no missiles available.

### DIFF
--- a/BahaTurret/BDArmorySettings.cs
+++ b/BahaTurret/BDArmorySettings.cs
@@ -538,6 +538,8 @@ namespace BahaTurret
 
 				if(cfg.HasValue("BDARMORY_WEAPONS_VOLUME")) BDARMORY_WEAPONS_VOLUME = float.Parse(cfg.GetValue("BDARMORY_WEAPONS_VOLUME"));
 
+				if(cfg.HasValue("MAX_GUARD_VISUAL_RANGE")) MAX_GUARD_VISUAL_RANGE = float.Parse(cfg.GetValue("MAX_GUARD_VISUAL_RANGE"));
+
 				if(cfg.HasValue("GLOBAL_LIFT_MULTIPLIER")) GLOBAL_LIFT_MULTIPLIER = float.Parse(cfg.GetValue("GLOBAL_LIFT_MULTIPLIER"));
 
 				if(cfg.HasValue("GLOBAL_DRAG_MULTIPLIER")) GLOBAL_DRAG_MULTIPLIER = float.Parse(cfg.GetValue("GLOBAL_DRAG_MULTIPLIER"));

--- a/BahaTurret/MissileFire.cs
+++ b/BahaTurret/MissileFire.cs
@@ -1783,7 +1783,11 @@ namespace BahaTurret
 						return false;
 					}
 
-					return SwitchToAirMissile();
+					if (SwitchToAirMissile ()) //Use missiles if available
+					{
+						return true;
+					}
+					return SwitchToTurret(distance); //Long range turrets?
 				}
 				else
 				{


### PR DESCRIPTION
I deemed shooting bullets at extreme ranges on non-responsive targets too easy, so I decided to let them shoot back. GUARD_MAX_VISUAL_RANGE is now read from the config file, and guards will now attempt to use guns on extreme ranges if no missiles are available.
