### PR TITLE
Guard mode will now use HEKVs.

### DIFF
--- a/BahaTurret/MissileFire.cs
+++ b/BahaTurret/MissileFire.cs
@@ -2159,7 +2159,7 @@ namespace BahaTurret
 				{
 					foreach(var ml in selectedWeapon.GetPart().FindModulesImplementing<MissileLauncher>())
 					{
-						if(ml.guidanceMode == MissileLauncher.GuidanceModes.AAMLead || ml.guidanceMode == MissileLauncher.GuidanceModes.AAMPure)
+						if(ml.guidanceMode == MissileLauncher.GuidanceModes.AAMLead || ml.guidanceMode == MissileLauncher.GuidanceModes.AAMPure || ml.guidanceMode == MissileLauncher.GuidanceModes.RCS)
 						{
 							return true;
 						}


### PR DESCRIPTION
Added RCS missiles to SwitchToAirMissile(), so that guard mode actually uses them.

Should vaccuum missiles have their own SwitchTo method instead?
