### PR TITLE
Fixed short range laser damage scaling.

### DIFF
--- a/BahaTurret/ModuleWeapon.cs
+++ b/BahaTurret/ModuleWeapon.cs
@@ -963,7 +963,8 @@ namespace BahaTurret
 						if(p && p.vessel && p.vessel!=this.vessel)
 						{
 							float distance = hit.distance;
-							p.temperature += laserDamage/(float)(Math.PI*Math.Pow(tanAngle*distance,2))*TimeWarp.fixedDeltaTime; //distance modifier: 1/(PI*Pow(Dist*tan(angle),
+							//Scales down the damage based on the increased surface area of the area being hit by the laser. Think flashlight on a wall.
+							p.temperature += laserDamage/(float)(1+Math.PI*Math.Pow(tanAngle*distance,2))*TimeWarp.fixedDeltaTime; 
 							
 							if(BDArmorySettings.INSTAKILL) p.temperature += p.maxTemp;
 						}


### PR DESCRIPTION
Previous calculations assumed the laser originated from a single spot, resulting in the amount of damage dealt by them on short ranges scaling wildly out of control. This is now fixed.

A flashlight on the wall is a good analogue for what the formula is doing - the further away you move, the wider the cone of light gets, and the less brightly lit any spot hit by that cone of light gets. Previously that area lit by the cone could go all the way down to zero if you moved the laser close enough, which completely broke the formula, so I simply made it so that the area is always at least one square meter and scales up from there.

The lasers might need some re-balancing with the changes, so to recap, you can adjust the laser's point blank damage with laserDamage, and the rate at which it scales down with tanAngle. Both are read from the part's config file.
