### PR TITLE
Made AI pilot's maximum extend range a tweakable.

### DIFF
--- a/BahaTurret/BDArmorySettings.cs
+++ b/BahaTurret/BDArmorySettings.cs
@@ -42,6 +42,7 @@ namespace BahaTurret
 		public static float BDARMORY_WEAPONS_VOLUME = 0.32f;
 
 		public static float MAX_GUARD_VISUAL_RANGE = 3500;
+		public static float MAX_PILOT_EXTEND_RANGE = 4000;
 
 
 		public static float GLOBAL_LIFT_MULTIPLIER = 0.20f;
@@ -602,6 +603,8 @@ namespace BahaTurret
 				if(cfg.HasValue("BDARMORY_WEAPONS_VOLUME")) BDARMORY_WEAPONS_VOLUME = float.Parse(cfg.GetValue("BDARMORY_WEAPONS_VOLUME"));
 
 				if(cfg.HasValue("MAX_GUARD_VISUAL_RANGE")) MAX_GUARD_VISUAL_RANGE = float.Parse(cfg.GetValue("MAX_GUARD_VISUAL_RANGE"));
+
+				if(cfg.HasValue("MAX_PILOT_EXTEND_RANGE")) MAX_PILOT_EXTEND_RANGE = float.Parse(cfg.GetValue("MAX_PILOT_EXTEND_RANGE"));
 
 				if(cfg.HasValue("GLOBAL_LIFT_MULTIPLIER")) GLOBAL_LIFT_MULTIPLIER = float.Parse(cfg.GetValue("GLOBAL_LIFT_MULTIPLIER"));
 

--- a/BahaTurret/BDArmorySettings.cs
+++ b/BahaTurret/BDArmorySettings.cs
@@ -42,8 +42,6 @@ namespace BahaTurret
 		public static float BDARMORY_WEAPONS_VOLUME = 0.32f;
 
 		public static float MAX_GUARD_VISUAL_RANGE = 3500;
-		public static float MAX_PILOT_EXTEND_RANGE = 4000;
-
 
 		public static float GLOBAL_LIFT_MULTIPLIER = 0.20f;
 		public static float GLOBAL_DRAG_MULTIPLIER = 4f;
@@ -603,8 +601,6 @@ namespace BahaTurret
 				if(cfg.HasValue("BDARMORY_WEAPONS_VOLUME")) BDARMORY_WEAPONS_VOLUME = float.Parse(cfg.GetValue("BDARMORY_WEAPONS_VOLUME"));
 
 				if(cfg.HasValue("MAX_GUARD_VISUAL_RANGE")) MAX_GUARD_VISUAL_RANGE = float.Parse(cfg.GetValue("MAX_GUARD_VISUAL_RANGE"));
-
-				if(cfg.HasValue("MAX_PILOT_EXTEND_RANGE")) MAX_PILOT_EXTEND_RANGE = float.Parse(cfg.GetValue("MAX_PILOT_EXTEND_RANGE"));
 
 				if(cfg.HasValue("GLOBAL_LIFT_MULTIPLIER")) GLOBAL_LIFT_MULTIPLIER = float.Parse(cfg.GetValue("GLOBAL_LIFT_MULTIPLIER"));
 

--- a/BahaTurret/BDModulePilotAI.cs
+++ b/BahaTurret/BDModulePilotAI.cs
@@ -353,7 +353,7 @@ namespace BahaTurret
 				}
 				else //extend if too close for agm attack
 				{
-					float extendDistance = Mathf.Clamp(weaponManager.guardRange - 1800, 2500, 4000);
+					float extendDistance = Mathf.Clamp(weaponManager.guardRange - 1800, 2500, BDArmorySettings.MAX_PILOT_EXTEND_RANGE);
 					float srfDist = Vector3.Distance(GetSurfacePosition(targetVessel.transform.position), GetSurfacePosition(vessel.transform.position));
 
 					if(srfDist < extendDistance && Vector3.Angle(vesselTransform.up, targetVessel.transform.position - vessel.transform.position) > 45)

--- a/BahaTurret/BDModulePilotAI.cs
+++ b/BahaTurret/BDModulePilotAI.cs
@@ -58,6 +58,10 @@ namespace BahaTurret
 		 UI_FloatRange(minValue = 150f, maxValue = 8500, stepIncrement = 10f, scene = UI_Scene.All)]
 		public float minAltitude = 900;
 
+		[KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Extend Range"),
+			UI_FloatRange(minValue = 2501f, maxValue = 50000f, stepIncrement = 100f, scene = UI_Scene.All)]
+		public float maxExtendRange = 4000f;
+
 		[KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Steer Factor"),
 		 UI_FloatRange(minValue = 0.1f, maxValue = 20f, stepIncrement = .1f, scene = UI_Scene.All)]
 		public float steerMult = 14;
@@ -353,7 +357,7 @@ namespace BahaTurret
 				}
 				else //extend if too close for agm attack
 				{
-					float extendDistance = Mathf.Clamp(weaponManager.guardRange - 1800, 2500, BDArmorySettings.MAX_PILOT_EXTEND_RANGE);
+					float extendDistance = Mathf.Clamp(weaponManager.guardRange - 1800, 2500, maxExtendRange);
 					float srfDist = Vector3.Distance(GetSurfacePosition(targetVessel.transform.position), GetSurfacePosition(vessel.transform.position));
 
 					if(srfDist < extendDistance && Vector3.Angle(vesselTransform.up, targetVessel.transform.position - vessel.transform.position) > 45)


### PR DESCRIPTION
Someone asked for this on the forum thread, so I made it happen. Pilot's extend range is now clamped to MAX_PILOT_EXTEND_RANGE (default value 4000) instead of a hard coded 4000. Remember to add the variable to settings.cfg if you decide to merge it.
