### PR TITLE
Made weapons action group fireable. Toggles firing on and off.

### DIFF
--- a/BahaTurret/ModuleWeapon.cs
+++ b/BahaTurret/ModuleWeapon.cs
@@ -197,6 +197,8 @@ namespace BahaTurret
 		Vector3 fixedLeadOffset = Vector3.zero;
 		float targetLeadDistance = 0;
 
+		//Fired via an action group
+		private bool agFired = false;
 
 		//SPECAL FEATURES
 
@@ -305,6 +307,12 @@ namespace BahaTurret
 		public void AGToggle(KSPActionParam param)
 		{
 			Toggle();
+		}
+
+		[KSPAction("Fire Weapon ON/OFF")]
+		public void AGFire(KSPActionParam param)
+		{
+			agFired = !agFired;
 		}
 
 
@@ -465,7 +473,7 @@ namespace BahaTurret
 				{
 					
 
-					userFiring = (BDInputUtils.GetKey(BDInputSettingsFields.WEAP_FIRE_KEY) && (vessel.isActiveVessel || BDArmorySettings.REMOTE_SHOOTING) && !MapView.MapIsEnabled && !aiControlled);
+					userFiring = (BDInputUtils.GetKey(BDInputSettingsFields.WEAP_FIRE_KEY) && (vessel.isActiveVessel || BDArmorySettings.REMOTE_SHOOTING) && !MapView.MapIsEnabled && !aiControlled) || agFired ;
 					if((userFiring || autoFire) && (yawRange == 0 || (maxPitch-minPitch) == 0 || turret.TargetInRange(finalAimTarget, 10, float.MaxValue)))
 					{
 						if(eWeaponType == WeaponTypes.Ballistic || eWeaponType == WeaponTypes.Cannon)


### PR DESCRIPTION
I noticed allmhuran asking for action group fireable weapons, so that they could be fired via kOS and the like. I saw no reason not to, so I went ahead and did it. Of course, you still can't control where the turret mounted weapons aim with kOS, but it's definitely an improvement to only being able to fire missiles with it.

I opted for a firing on/off switch instead of a single action group activation, single shot approach, since I figured firing something like a laser would be a bit of a pain otherwise.
