### PR TITLE
Update ModuleWeapon.cs

### DIFF
--- a/BahaTurret/ModuleWeapon.cs
+++ b/BahaTurret/ModuleWeapon.cs
@@ -204,7 +204,7 @@ namespace BahaTurret
 		[KSPField]
 		public bool airDetonation = false;
 		[KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Default Detonation Range"),
-		 UI_FloatRange(minValue = 500, maxValue = 22500f, stepIncrement = 1f, scene = UI_Scene.All)]
+		 UI_FloatRange(minValue = 500, maxValue = BDArmorySettings.MAX_BULLET_RANGE, stepIncrement = 1f, scene = UI_Scene.All)]
 		public float defaultDetonationRange = 3500;
 		float detonationRange = 2000;
 

--- a/BahaTurret/ModuleWeapon.cs
+++ b/BahaTurret/ModuleWeapon.cs
@@ -204,7 +204,7 @@ namespace BahaTurret
 		[KSPField]
 		public bool airDetonation = false;
 		[KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Default Detonation Range"),
-		 UI_FloatRange(minValue = 500, maxValue = 3500f, stepIncrement = 1f, scene = UI_Scene.All)]
+		 UI_FloatRange(minValue = 500, maxValue = 225000f, stepIncrement = 1f, scene = UI_Scene.All)]
 		public float defaultDetonationRange = 3500;
 		float detonationRange = 2000;
 

--- a/BahaTurret/ModuleWeapon.cs
+++ b/BahaTurret/ModuleWeapon.cs
@@ -204,7 +204,7 @@ namespace BahaTurret
 		[KSPField]
 		public bool airDetonation = false;
 		[KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Default Detonation Range"),
-		 UI_FloatRange(minValue = 500, maxValue = BDArmorySettings.MAX_BULLET_RANGE, stepIncrement = 1f, scene = UI_Scene.All)]
+		 UI_FloatRange(minValue = 500, maxValue = 22500, stepIncrement = 1f, scene = UI_Scene.All)]
 		public float defaultDetonationRange = 3500;
 		float detonationRange = 2000;
 

--- a/BahaTurret/ModuleWeapon.cs
+++ b/BahaTurret/ModuleWeapon.cs
@@ -204,7 +204,7 @@ namespace BahaTurret
 		[KSPField]
 		public bool airDetonation = false;
 		[KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Default Detonation Range"),
-		 UI_FloatRange(minValue = 500, maxValue = 225000f, stepIncrement = 1f, scene = UI_Scene.All)]
+		 UI_FloatRange(minValue = 500, maxValue = 22500f, stepIncrement = 1f, scene = UI_Scene.All)]
 		public float defaultDetonationRange = 3500;
 		float detonationRange = 2000;
 


### PR DESCRIPTION
Increased max air detonation distance, as now vessels in the atmosphere can load up to 22.5km away in stock game. It's somewhat annoying to see dual-porpose weapons limited by this.
